### PR TITLE
Allow simple ko tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/jwalterweatherman v0.0.0-20170901151539-12bd96e66386 // indirect
 	github.com/spf13/pflag v0.0.0-20171020110617-97afa5e7ca8a // indirect
 	github.com/spf13/viper v0.0.0-20171020104009-8ef37cbca716
-	github.com/stretchr/testify v1.2.2 // indirect
+	github.com/stretchr/testify v1.2.2
 	golang.org/x/net v0.0.0-20180926154720-4dfa2610cdf3 // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/sys v0.0.0-20171017063910-8dbc5d05d6ed // indirect

--- a/lang/go/gate/gate.go
+++ b/lang/go/gate/gate.go
@@ -1,3 +1,19 @@
+//
+// Copyright © 2018 Aljabr, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package gate
 
 import (

--- a/lang/go/gate/gate_test.go
+++ b/lang/go/gate/gate_test.go
@@ -1,8 +1,26 @@
+//
+// Copyright © 2018 Aljabr, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package gate
 
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/kocircuit/kocircuit/lang/go/runtime"
 )
@@ -13,7 +31,16 @@ type testGateOk struct {
 	Y   *testGateOk `ko:"name=y"`
 }
 
+type testGateSimple struct {
+	S    string `ko:"str"`
+	MonS string `ko:"mstr,monadic"`
+}
+
 func (testGateOk) Play(*runtime.Context) *complex128 {
+	return nil
+}
+
+func (testGateSimple) Play(*runtime.Context) error {
 	return nil
 }
 
@@ -21,4 +48,42 @@ func TestBindGate(t *testing.T) {
 	if _, err := BindGate(reflect.TypeOf(&testGateOk{})); err != nil {
 		t.Errorf("bind (%v)", err)
 	}
+}
+
+func TestGateFieldName(t *testing.T) {
+	g, err := BindGate(reflect.TypeOf(&testGateOk{}))
+	if err != nil {
+		t.Fatalf("bind (%v)", err)
+	}
+	f, found := g.Struct.FieldByKoName("etc")
+	assert.True(t, found)
+	assert.Equal(t, f.KoName(), "etc")
+	assert.Equal(t, f.GoName(), "Etc")
+	assert.True(t, f.IsMonadic())
+
+	f, found = g.Struct.FieldByKoName("x")
+	assert.True(t, found)
+	assert.Equal(t, f.KoName(), "x")
+	assert.Equal(t, f.GoName(), "X")
+	assert.False(t, f.IsMonadic())
+
+	g, err = BindGate(reflect.TypeOf(&testGateSimple{}))
+	if err != nil {
+		t.Fatalf("bind (%v)", err)
+	}
+
+	f, found = g.Struct.FieldByKoName("str")
+	assert.True(t, found)
+	assert.Equal(t, f.KoName(), "str")
+	assert.Equal(t, f.GoName(), "S")
+	assert.False(t, f.IsMonadic())
+
+	f, found = g.Struct.FieldByKoName("mstr")
+	assert.True(t, found)
+	assert.Equal(t, f.KoName(), "mstr")
+	assert.Equal(t, f.GoName(), "MonS")
+	assert.True(t, f.IsMonadic())
+
+	_, found = g.Struct.FieldByKoName("notFound")
+	assert.False(t, found)
 }

--- a/lang/go/gate/name.go
+++ b/lang/go/gate/name.go
@@ -1,3 +1,19 @@
+//
+// Copyright © 2018 Aljabr, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package gate
 
 import (
@@ -30,9 +46,11 @@ func StructFieldKoProtoGoName(sf reflect.StructField) (string, bool) {
 	return structFieldGoName(sf)
 }
 
+// structFieldKoName looks up the Ko name of the given field.
+// Returns: KoName, NameFound
 func structFieldKoName(sf reflect.StructField) (string, bool) {
-	tag := sf.Tag.Get("ko")
-	for _, kv := range strings.Split(tag, ",") {
+	splittedTag := strings.Split(sf.Tag.Get("ko"), ",")
+	for _, kv := range splittedTag {
 		x := strings.SplitN(kv, "=", 2)
 		switch len(x) {
 		case 2:
@@ -41,7 +59,9 @@ func structFieldKoName(sf reflect.StructField) (string, bool) {
 			}
 		}
 	}
-	return "", false
+	// No explicit `name=Foo` found, use first entry
+	name := splittedTag[0]
+	return name, name != ""
 }
 
 func structFieldGoName(sf reflect.StructField) (string, bool) {

--- a/lang/go/gate/proto.go
+++ b/lang/go/gate/proto.go
@@ -1,3 +1,19 @@
+//
+// Copyright © 2018 Aljabr, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package gate
 
 import (


### PR DESCRIPTION
This PR adds support for struct field tags like `ko:"myName"`
in addition to the existing `ko:"name=myName"` format.

fixes #16